### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ r.result contains the object that was retured by the C SecItemAdd underlying fun
 
 iOS 8.0 or above
 You have to use cocoapod compiled from the Swift branch, since the master branch of cocoapods still does not fully support Swift. 
-See: [Using Cocoapods Unreleased Features](http://guides.cocoapods.org/using/unreleased-features)
+See: [Using CocoaPods Unreleased Features](http://guides.cocoapods.org/using/unreleased-features)
 
 ## Installation
 


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
